### PR TITLE
Remove duplicated method

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -28,7 +28,7 @@ impl Device {
         }
     }
 
-    /// Returns the vendor ID of this device, or NULL if this information couldn't be obtained. This
+    /// Returns the vendor ID of this device, or None if this information couldn't be obtained. This
     /// ID is retrieved from the device, and is thus constant for it.
     ///
     /// This function, together with gdk_device_get_product_id(), can be used to eg. compose GSettings
@@ -47,16 +47,6 @@ impl Device {
     ///     g_settings_new_with_path(DEVICE_SCHEMA, path);
     /// }
     /// ```
-    #[cfg(gdk_3_16)]
-    pub fn get_vendor_id(&self) -> Option<String> {
-        unsafe {
-            from_glib_none(ffi::gdk_device_get_vendor_id(self.to_glib_none().0))
-        }
-    }
-
-    /// Returns the product ID of this device, or None if this information couldn't be obtained. This
-    /// ID is retrieved from the device, and is thus constant for it. See Device::get_vendor_id() for
-    /// more information.
     #[cfg(gdk_3_16)]
     pub fn get_vendor_id(&self) -> Option<String> {
         unsafe {


### PR DESCRIPTION
Hello,
compiling gdk (and gtk and so on) failed for me because `get_vendor_id` is defined twice. Maybe the second method is at the wrong place (the other method is referenced in the documentation comment)?