### PR TITLE
Add FromGlibFull and GValue support to Rectangle

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -190,6 +190,7 @@ version = "3.8"
 [[object]]
 name = "Gdk.Monitor"
 status = "generate"
+version = "3.22"
     [[object.property]]
     name = "subpixel-layout"
     version = "3.22"

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -37,7 +37,9 @@ mod g_l_context;
 #[cfg(feature = "v3_16")]
 pub use self::g_l_context::GLContext;
 
+#[cfg(feature = "v3_22")]
 mod monitor;
+#[cfg(feature = "v3_22")]
 pub use self::monitor::Monitor;
 
 mod screen;

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -5,7 +5,11 @@
 use std::convert::{AsRef, From};
 use std::mem;
 
+use glib;
 use glib::translate::*;
+use glib_ffi;
+use glib_ffi::gconstpointer;
+use gobject_ffi;
 use cairo::RectangleInt;
 use ffi;
 
@@ -86,6 +90,24 @@ impl FromGlibPtrNone<*mut ffi::GdkRectangle> for Rectangle {
     }
 }
 
+#[doc(hidden)]
+impl FromGlibPtrFull<*mut ffi::GdkRectangle> for Rectangle {
+    unsafe fn from_glib_full(ptr: *mut ffi::GdkRectangle) -> Self {
+        let rect = *(ptr as *mut Rectangle);
+        glib_ffi::g_free(ptr as *mut _);
+        rect
+    }
+}
+
+#[doc(hidden)]
+impl FromGlibPtrFull<*const ffi::GdkRectangle> for Rectangle {
+    unsafe fn from_glib_full(ptr: *const ffi::GdkRectangle) -> Self {
+        let rect = *(ptr as *const Rectangle);
+        glib_ffi::g_free(ptr as *mut _);
+        rect
+    }
+}
+
 impl AsRef<RectangleInt> for Rectangle {
     fn as_ref(&self) -> &RectangleInt {
         unsafe { mem::transmute(self) }
@@ -96,5 +118,32 @@ impl From<RectangleInt> for Rectangle {
     fn from(r: RectangleInt) -> Rectangle {
         skip_assert_initialized!();
         unsafe { mem::transmute(r) }
+    }
+}
+
+impl glib::StaticType for Rectangle {
+    fn static_type() -> glib::types::Type {
+        skip_assert_initialized!();
+        unsafe { from_glib(ffi::gdk_rectangle_get_type()) }
+    }
+}
+
+impl glib::value::FromValueOptional for Rectangle {
+    unsafe fn from_value_optional(value: &glib::Value) -> Option<Self> {
+        from_glib_full(gobject_ffi::g_value_dup_boxed(value.to_glib_none().0) as *mut ffi::GdkRectangle)
+    }
+}
+
+impl glib::value::SetValue for Rectangle {
+    unsafe fn set_value(value: &mut glib::Value, this: &Self)  {
+        gobject_ffi::g_value_set_boxed(value.to_glib_none_mut().0,
+                                       this.to_glib_none().0 as gconstpointer)
+    }
+}
+
+impl glib::value::SetValueOptional for Rectangle {
+    unsafe fn set_value_optional(value: &mut glib::Value, this: Option<&Self>) {
+        gobject_ffi::g_value_set_boxed(value.to_glib_none_mut().0,
+                                       this.to_glib_none().0 as gconstpointer)
     }
 }


### PR DESCRIPTION
Tested on `Monitor` properties `geometry` and `workarea`.
As `Monitor` has normal getters `get_geometry` for v3.22 these properties will be ignored,
so I make PR before https://github.com/gtk-rs/gir/pull/328 merged

Also fixed `Monitor` starting version