### PR TITLE
Update RGBA/Rectangle FromValueOptional impls for newly added lifetim…

### DIFF
--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -128,8 +128,8 @@ impl glib::StaticType for Rectangle {
     }
 }
 
-impl glib::value::FromValueOptional for Rectangle {
-    unsafe fn from_value_optional(value: &glib::Value) -> Option<Self> {
+impl<'a> glib::value::FromValueOptional<'a> for Rectangle {
+    unsafe fn from_value_optional(value: &'a glib::Value) -> Option<Self> {
         from_glib_full(gobject_ffi::g_value_dup_boxed(value.to_glib_none().0) as *mut ffi::GdkRectangle)
     }
 }

--- a/src/rgba.rs
+++ b/src/rgba.rs
@@ -179,8 +179,8 @@ impl glib::StaticType for RGBA {
     }
 }
 
-impl glib::value::FromValueOptional for RGBA {
-    unsafe fn from_value_optional(value: &glib::Value) -> Option<Self> {
+impl<'a> glib::value::FromValueOptional<'a> for RGBA {
+    unsafe fn from_value_optional(value: &'a glib::Value) -> Option<Self> {
         from_glib_full(gobject_ffi::g_value_dup_boxed(value.to_glib_none().0) as *mut ffi::GdkRGBA)
     }
 }


### PR DESCRIPTION
…e parameter


See https://github.com/gtk-rs/glib/pull/162
As a next step, these two impls can actually benefit from being there for &Rectangle and &RGBA too to prevent some copying. I'll add those later.