### PR TITLE
Fix transfer full conversion of Atom arrays

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -100,15 +100,14 @@ impl FromGlibPtrFull<ffi::GdkAtom> for Atom {
 }
 
 impl FromGlibContainerAsVec<ffi::GdkAtom, *mut ffi::GdkAtom> for Atom {
-    unsafe fn from_glib_none_num_as_vec(mut ptr: *mut ffi::GdkAtom, num: usize) -> Vec<Self> {
+    unsafe fn from_glib_none_num_as_vec(ptr: *mut ffi::GdkAtom, num: usize) -> Vec<Self> {
         if num == 0 || ptr.is_null() {
             return Vec::new();
         }
 
         let mut res = Vec::with_capacity(num);
-        for _ in 0..num {
-            res.push(from_glib_none(ptr::read(ptr)));
-            ptr = ptr.offset(1);
+        for i in 0..num {
+            res.push(from_glib_none(ptr::read(ptr.offset(i as isize))));
         }
         res
     }
@@ -119,15 +118,14 @@ impl FromGlibContainerAsVec<ffi::GdkAtom, *mut ffi::GdkAtom> for Atom {
         res
     }
 
-    unsafe fn from_glib_full_num_as_vec(mut ptr: *mut ffi::GdkAtom, num: usize) -> Vec<Self> {
+    unsafe fn from_glib_full_num_as_vec(ptr: *mut ffi::GdkAtom, num: usize) -> Vec<Self> {
         if num == 0 || ptr.is_null() {
             return Vec::new();
         }
 
         let mut res = Vec::with_capacity(num);
-        for _ in 0..num {
-            res.push(from_glib_full(ptr::read(ptr)));
-            ptr = ptr.offset(1);
+        for i in 0..num {
+            res.push(from_glib_full(ptr::read(ptr.offset(i as isize))));
         }
         glib_ffi::g_free(ptr as *mut _);
         res


### PR DESCRIPTION
Instead of the original pointer, the pointer at the end of the array was
being freed.