### PR TITLE
FrameTimings: use an `Option` when returning presentation time

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -286,6 +286,14 @@ status = "generate"
 name = "Gdk.FrameTimings"
 status = "generate"
 version = "3.8"
+    [[object.function]]
+    name = "get_predicted_presentation_time"
+    # Use an `Option` for the return value
+    ignore = true
+    [[object.function]]
+    name = "get_presentation_time"
+    # Use an `Option` for the return value
+    ignore = true
 
 [[object]]
 name = "Gdk.Monitor"

--- a/src/auto/frame_timings.rs
+++ b/src/auto/frame_timings.rs
@@ -43,20 +43,6 @@ impl FrameTimings {
     }
 
     #[cfg(any(feature = "v3_8", feature = "dox"))]
-    pub fn get_predicted_presentation_time(&self) -> i64 {
-        unsafe {
-            ffi::gdk_frame_timings_get_predicted_presentation_time(self.to_glib_none().0)
-        }
-    }
-
-    #[cfg(any(feature = "v3_8", feature = "dox"))]
-    pub fn get_presentation_time(&self) -> i64 {
-        unsafe {
-            ffi::gdk_frame_timings_get_presentation_time(self.to_glib_none().0)
-        }
-    }
-
-    #[cfg(any(feature = "v3_8", feature = "dox"))]
     pub fn get_refresh_interval(&self) -> i64 {
         unsafe {
             ffi::gdk_frame_timings_get_refresh_interval(self.to_glib_none().0)

--- a/src/frame_timings.rs
+++ b/src/frame_timings.rs
@@ -1,0 +1,32 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::translate::*;
+use ffi;
+use std::num::NonZeroU64;
+use FrameTimings;
+
+impl FrameTimings {
+    #[cfg(any(feature = "v3_8", feature = "dox"))]
+    pub fn get_predicted_presentation_time(&self) -> Option<NonZeroU64> {
+        let predicted_presentation_time = unsafe {
+            ffi::gdk_frame_timings_get_predicted_presentation_time(self.to_glib_none().0)
+        };
+        // assuming presentation time is always positive
+        assert!(predicted_presentation_time >= 0);
+        // `0` means the value is not available
+        NonZeroU64::new(predicted_presentation_time as u64)
+    }
+
+    #[cfg(any(feature = "v3_8", feature = "dox"))]
+    pub fn get_presentation_time(&self) -> Option<NonZeroU64> {
+        let presentation_time = unsafe {
+            ffi::gdk_frame_timings_get_presentation_time(self.to_glib_none().0)
+        };
+        // assuming presentation time is always positive
+        assert!(presentation_time >= 0);
+        // `0` means the value is not available
+        NonZeroU64::new(presentation_time as u64)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ mod event_visibility;
 mod event_window_state;
 #[cfg(any(feature = "v3_8", feature = "dox"))]
 mod frame_clock;
+#[cfg(any(feature = "v3_8", feature = "dox"))]
+mod frame_timings;
 mod functions;
 mod geometry;
 mod keys;


### PR DESCRIPTION
`get_presentation_time` and `get_predicted_presentation_time` can both return `0` when the returned value is not available. In Rust, using an `Option` and returning `None` would make it clear that the value shouldn't be used as is.

See #250