### PR TITLE
FrameTimings: use an `Option` when returning refresh_interval

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -294,6 +294,10 @@ version = "3.8"
     name = "get_presentation_time"
     # Use an `Option` for the return value
     ignore = true
+    [[object.function]]
+    name = "get_refresh_interval"
+    # Use an `Option` for the return value
+    ignore = true
 
 [[object]]
 name = "Gdk.Monitor"

--- a/src/auto/frame_timings.rs
+++ b/src/auto/frame_timings.rs
@@ -41,11 +41,4 @@ impl FrameTimings {
             ffi::gdk_frame_timings_get_frame_time(self.to_glib_none().0)
         }
     }
-
-    #[cfg(any(feature = "v3_8", feature = "dox"))]
-    pub fn get_refresh_interval(&self) -> i64 {
-        unsafe {
-            ffi::gdk_frame_timings_get_refresh_interval(self.to_glib_none().0)
-        }
-    }
 }

--- a/src/frame_timings.rs
+++ b/src/frame_timings.rs
@@ -29,4 +29,15 @@ impl FrameTimings {
         // `0` means the value is not available
         NonZeroU64::new(presentation_time as u64)
     }
+
+    #[cfg(any(feature = "v3_8", feature = "dox"))]
+    pub fn get_refresh_interval(&self) -> Option<NonZeroU64> {
+        let refresh_interval = unsafe {
+            ffi::gdk_frame_timings_get_refresh_interval(self.to_glib_none().0)
+        };
+        // assuming refresh interval is always positive
+        assert!(refresh_interval >= 0);
+        // `0` means the value is not available
+        NonZeroU64::new(refresh_interval as u64)
+    }
 }


### PR DESCRIPTION
`gdk_frame_timings_get_refresh_interval` [returns `0` when the value is not available](https://developer.gnome.org/gdk3/stable/gdk3-GdkFrameTimings.html#gdk-frame-timings-get-refresh-interval).

Same as https://github.com/gtk-rs/gdk/pull/251.