### PR TITLE
Support const array of gdk::Atom

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -94,7 +94,7 @@ impl<'a> ToGlibContainerFromSlice<'a, *mut ffi::GdkAtom> for &'a Atom {
         let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
 
         let v_ptr = unsafe {
-            let v_ptr = glib_ffi::g_malloc0(mem::size_of::<ffi::GdkAtom>() * t.len() + 1) as *mut ffi::GdkAtom;
+            let v_ptr = glib_ffi::g_malloc0(mem::size_of::<ffi::GdkAtom>() * (t.len() + 1)) as *mut ffi::GdkAtom;
 
             for (i, s) in v.iter().enumerate() {
                 ptr::write(v_ptr.offset(i as isize), s.0);
@@ -107,6 +107,44 @@ impl<'a> ToGlibContainerFromSlice<'a, *mut ffi::GdkAtom> for &'a Atom {
     }
 
     fn to_glib_full_from_slice(_: &[&'a Atom]) -> *mut ffi::GdkAtom {
+        skip_assert_initialized!();
+
+        unimplemented!()
+    }
+}
+
+impl<'a> ToGlibContainerFromSlice<'a, *const ffi::GdkAtom> for &'a Atom {
+    type Storage = (Vec<Stash<'a, ffi::GdkAtom, &'a Atom>>, Option<Vec<ffi::GdkAtom>>);
+
+    fn to_glib_none_from_slice(t: &'a [&'a Atom]) -> (*const ffi::GdkAtom, Self::Storage) {
+        skip_assert_initialized!();
+
+        let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
+        let mut v_ptr: Vec<_> = v.iter().map(|s| s.0).collect();
+        v_ptr.push(ptr::null_mut());
+
+        (v_ptr.as_ptr() as *const ffi::GdkAtom, (v, Some(v_ptr)))
+    }
+
+    fn to_glib_container_from_slice(t: &'a [&'a Atom]) -> (*const ffi::GdkAtom, Self::Storage) {
+        skip_assert_initialized!();
+
+        let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
+
+        let v_ptr = unsafe {
+            let v_ptr = glib_ffi::g_malloc0(mem::size_of::<ffi::GdkAtom>() * (t.len() + 1)) as *mut ffi::GdkAtom;
+
+            for (i, s) in v.iter().enumerate() {
+                ptr::write(v_ptr.offset(i as isize), s.0);
+            }
+
+            v_ptr as *const ffi::GdkAtom
+        };
+
+        (v_ptr, (v, None))
+    }
+
+    fn to_glib_full_from_slice(_: &[&'a Atom]) -> *const ffi::GdkAtom {
         skip_assert_initialized!();
 
         unimplemented!()


### PR DESCRIPTION
Will be needed for https://github.com/gtk-rs/gir-files/pull/32, but can be done before.

cc @GuillaumeGomez , @sdroege 