### PR TITLE
Replace atom borrow

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -156,6 +156,11 @@ impl FromGlibPtrNone<ffi::GdkAtom> for Atom {
     unsafe fn from_glib_none(ptr: ffi::GdkAtom) -> Atom { Atom(ptr) }
 }
 
+impl FromGlibPtrBorrow<ffi::GdkAtom> for Atom {
+    #[inline]
+    unsafe fn from_glib_borrow(ptr: ffi::GdkAtom) -> Atom { Atom(ptr) }
+}
+
 impl FromGlibPtrFull<ffi::GdkAtom> for Atom {
     #[inline]
     unsafe fn from_glib_full(_: ffi::GdkAtom) -> Atom { unimplemented!() }
@@ -212,19 +217,5 @@ impl<'a> From<&'a str> for Atom {
     fn from(r: &'a str) -> Atom {
         skip_assert_initialized!();
         Atom::intern(r)
-    }
-}
-
-#[doc(hidden)]
-impl FromGlibPtrBorrow<*const ffi::GdkAtom> for Atom {
-    unsafe fn from_glib_borrow(ptr: *const ffi::GdkAtom) -> Self {
-        Atom(*ptr)
-    }
-}
-
-#[doc(hidden)]
-impl FromGlibPtrBorrow<*mut ffi::GdkAtom> for Atom {
-    unsafe fn from_glib_borrow(ptr: *mut ffi::GdkAtom) -> Self {
-        Atom(*ptr)
     }
 }


### PR DESCRIPTION
Previous has wrong input types (not fully sure that it unneeded totally)
so regenerated gtk shows this error:
```
error[E0277]: the trait bound `gdk::Atom: glib::translate::FromGlibPtrBorrow<*mut gdk_ffi::_GdkAtom>` is not satisfied
  --> D:/eap/rust/0/gtk\src\auto\clipboard.rs:89:26
   |
89 |             let format = from_glib_borrow(format);
   |                          ^^^^^^^^^^^^^^^^ the trait `glib::translate::FromGlibPtrBorrow<*mut gdk_ffi::_GdkAtom>` is not implemented for `gdk::Atom`
   |
   = help: the following implementations were found:
             <gdk::Atom as glib::translate::FromGlibPtrBorrow<*const *mut gdk_ffi::_GdkAtom>>
             <gdk::Atom as glib::translate::FromGlibPtrBorrow<*mut *mut gdk_ffi::_GdkAtom>>
   = note: required by `glib::translate::from_glib_borrow`
```
cc @GuillaumeGomez , @sdroege 