### PR TITLE
Fix up cairo interaction extension traits

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,5 +5,5 @@
 //! Traits intended for blanket imports.
 
 pub use auto::traits::*;
-pub use cairo_interaction::{ContextExt, PixbufExt, SurfaceExt};
+pub use cairo_interaction::{GdkContextExt, GdkPixbufExt, GdkSurfaceExt};
 pub use window::WindowExtManual;


### PR DESCRIPTION
- Remove duplicated ContextExt::cairo_surface_create_from_pixbuf(). It
  already exists as PixbufExt::create_surface()
- Rename ContextExt::cairo_draw_from_gl() to draw_from_gl() and take the
  context as &self
- Mark ContextExt::draw_from_gl as unsafe! It takes random integers for
  GL resources, which are basically like pointers and must be taken care
  of to be correct and valid.
- Change all functions taking a gdk::Window to take a IsA<gdk::Window>
- Rename all traits to include the Gdk prefix for preventing naming
  conflicts.

Fixes https://github.com/gtk-rs/gdk/issues/308