### PR TITLE
Add keyval_to/is_upper/lower functions to `Key` struct

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -7,16 +7,6 @@ use glib::translate::*;
 use glib::GString;
 use libc::c_uint;
 
-pub fn keyval_name(keyval: u32) -> Option<GString> {
-    skip_assert_initialized!();
-    unsafe { from_glib_none(gdk_sys::gdk_keyval_name(keyval as c_uint)) }
-}
-
-pub fn keyval_to_unicode(keyval: u32) -> Option<char> {
-    skip_assert_initialized!();
-    unsafe { ::std::char::from_u32(gdk_sys::gdk_keyval_to_unicode(keyval)).filter(|x| *x != '\0') }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key(u32);
 
@@ -31,6 +21,13 @@ impl ::std::ops::Deref for Key {
 impl ::std::ops::DerefMut for Key {
     fn deref_mut(&mut self) -> &mut u32 {
         &mut self.0
+    }
+}
+
+impl ::std::convert::From<u32> for Key {
+    fn from(value: u32) -> Self {
+        skip_assert_initialized!();
+        Key(value)
     }
 }
 
@@ -51,11 +48,35 @@ impl ToGlib for Key {
 
 impl Key {
     pub fn to_unicode(&self) -> Option<char> {
-        keyval_to_unicode(**self)
+        skip_assert_initialized!();
+        unsafe {
+            ::std::char::from_u32(gdk_sys::gdk_keyval_to_unicode(**self)).filter(|x| *x != '\0')
+        }
     }
 
     pub fn name(&self) -> Option<GString> {
-        keyval_name(**self)
+        skip_assert_initialized!();
+        unsafe { from_glib_none(gdk_sys::gdk_keyval_name(**self as c_uint)) }
+    }
+
+    pub fn is_upper(&self) -> bool {
+        skip_assert_initialized!();
+        unsafe { from_glib(gdk_sys::gdk_keyval_is_upper(**self)) }
+    }
+
+    pub fn is_lower(&self) -> bool {
+        skip_assert_initialized!();
+        unsafe { from_glib(gdk_sys::gdk_keyval_is_lower(**self)) }
+    }
+
+    pub fn to_upper(&self) -> Self {
+        skip_assert_initialized!();
+        unsafe { gdk_sys::gdk_keyval_to_upper(**self) }.into()
+    }
+
+    pub fn to_lower(&self) -> Self {
+        skip_assert_initialized!();
+        unsafe { gdk_sys::gdk_keyval_to_lower(**self) }.into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,6 @@ pub use window::WindowAttr;
 #[allow(non_camel_case_types)]
 pub type key = i32;
 
-pub use self::keys::{keyval_name, keyval_to_unicode};
-
 /// The primary button. This is typically the left mouse button, or the right button in a left-handed setup.
 pub const BUTTON_PRIMARY: u32 = gdk_sys::GDK_BUTTON_PRIMARY as u32;
 

--- a/tests/check_event.rs
+++ b/tests/check_event.rs
@@ -8,15 +8,11 @@ fn check_event() {
     let mut ev: gdk::EventKey = base_ev.downcast().unwrap();
     ev.as_mut().keyval = *gdk::keys::constants::A;
 
-    let keyval = gdk::keyval_to_unicode(*ev.get_keyval());
-    let keyval2 = ev.get_keyval().to_unicode();
+    let keyval_unicode = ev.get_keyval().to_unicode();
 
-    assert_eq!(keyval, Some('A'));
-    assert_eq!(keyval, keyval2);
+    assert_eq!(keyval_unicode, Some('A'));
 
-    let name = gdk::keyval_name(*ev.get_keyval());
-    let name2 = ev.get_keyval().name();
+    let keyval_name = ev.get_keyval().name();
 
-    assert_eq!(name, Some("A".into()));
-    assert_eq!(name, name2);
+    assert_eq!(keyval_name, Some("A".into()));
 }


### PR DESCRIPTION
added:
- `keyval_is_upper`
- `keyval_is_lower` 
- `keyval_to_upper` 
- `keyval_to_lower`

As I could not use them in my project in the recent versions, [here]( 
https://github.com/Amjad50/plastic/blob/984590c4ede15b9ed8e028d16ea4b66a9addbfcc/nes_ui_gtk/src/ui.rs#L145), As `u32` cannot be converted back into `Key`

what do you think? @GuillaumeGomez 
